### PR TITLE
fix Issue#33

### DIFF
--- a/src/main/java/com/utn/ProgIII/mapper/ProductSupplierMapper.java
+++ b/src/main/java/com/utn/ProgIII/mapper/ProductSupplierMapper.java
@@ -70,7 +70,7 @@ public class ProductSupplierMapper {
     public Double shortenDouble(Double number)
     {
         String s = String.format("%.5f", number);
-        return Double.parseDouble(s);
+        return Double.parseDouble(s.replace(",", "."));
     }
 }
 

--- a/src/main/java/com/utn/ProgIII/service/implementations/SupplierServiceImpl.java
+++ b/src/main/java/com/utn/ProgIII/service/implementations/SupplierServiceImpl.java
@@ -8,7 +8,6 @@ import com.utn.ProgIII.model.Address.Address;
 import com.utn.ProgIII.model.Supplier.QSupplier;
 import com.utn.ProgIII.model.Supplier.Supplier;
 import com.utn.ProgIII.dto.ViewSupplierDTO;
-import com.utn.ProgIII.model.User.QUser;
 import com.utn.ProgIII.repository.SupplierRepository;
 import com.utn.ProgIII.service.interfaces.SupplierService;
 import com.utn.ProgIII.validations.SupplierValidations;
@@ -77,7 +76,6 @@ public class SupplierServiceImpl implements SupplierService {
     /**
      * Elimina un proveedor en caso de que exista
      * @param id El ID del proveedor
-     * @return un booleano representando el éxito.
      */
     @Override
     public void deleteSupplier(long id) {

--- a/src/main/resources/db/migration/V4__add_ecommerce_tables.sql
+++ b/src/main/resources/db/migration/V4__add_ecommerce_tables.sql
@@ -1,22 +1,3 @@
-CREATE TABLE `shopping_session` (
-    `shopping_session_id` BIGINT AUTO_INCREMENT PRIMARY KEY ,
-    `user_id` BIGINT NOT NULL,
-    `total` DECIMAL(10,2),
-    `created_at` TIMESTAMP,
-    `modified_at` TIMESTAMP,
-    CONSTRAINT FK_shopping_session_user FOREIGN KEY shopping_session(shopping_session_id) references user(id_user)
-);
-
-CREATE TABLE `cart_item` (
-    `cart_item_id` BIGINT AUTO_INCREMENT PRIMARY KEY ,
-    `product_id` BIGINT NOT NULL ,
-    `session_id` BIGINT NOT NULL ,
-    `unit_price` DECIMAL(10,2) NOT NULL ,
-    `quantity` FLOAT NOT NULL,
-    CONSTRAINT FK_cart_item_session FOREIGN KEY cart_item (session_id) references shopping_session(shopping_session_id),
-    CONSTRAINT FK_cart_item_product FOREIGN KEY cart_item (product_id) references product(id_product)
-);
-
 CREATE TABLE `order_details` (
     `order_details_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
     `user_id` BIGINT NOT NULL ,


### PR DESCRIPTION
add .replace to string on shortenDouble method to avoid NumberFormatException to be throw.

The exception was thrown because the input string has a "," instead of "." a double with comma separator isn't a valid candidate to convert in parseDouble method. 

fixes #33 